### PR TITLE
Selection of new rustup profile minimal introduced with rustup version 1.20.0

### DIFF
--- a/lib/rustup.js
+++ b/lib/rustup.js
@@ -37,7 +37,7 @@ function installOnUnix() {
     return __awaiter(this, void 0, void 0, function* () {
         let script = yield toolCache.downloadTool("https://sh.rustup.rs");
         fs_1.chmodSync(script, '777');
-        yield exec.exec(`"${script}"`, ['-y', '--default-toolchain', 'none']);
+        yield exec.exec(`"${script}"`, ['-y', '--default-toolchain', 'none', '--profile=minimal']);
         return path.join(process.env['HOME'] || '', '.cargo');
     });
 }

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
-import * as io from '@actions/io';
 import * as toolCache from '@actions/tool-cache';
 import * as path from 'path';
 import * as os from 'os';
@@ -22,7 +21,7 @@ async function installOnUnix(): Promise<string> {
   let script = await toolCache.downloadTool("https://sh.rustup.rs");
 
   chmodSync(script, '777');
-  await exec.exec(`"${script}"`, ['-y', '--default-toolchain', 'none']);
+  await exec.exec(`"${script}"`, ['-y', '--default-toolchain', 'none', '--profile=minimal']);
 
   return path.join(process.env['HOME'] || '', '.cargo');
 }


### PR DESCRIPTION
This should speed up the installation. 
See the release notes of [1.20.0](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html).
