### PR TITLE
update rustup before for reliable nightly toolchain tool availability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,11 @@ async function run() {
 
     if(version) {
       await rustup.install();
+      if (os.platform() !== 'darwin') {
+        // update the GitHub managed VM version of rustup
+        // to leverage newer features like "latest latest compatible nightly"
+        await exec.exec('rustup', ['self', 'update']);
+      }
       await exec.exec('rustup', ['default', version]);
       await exec.exec('rustup', ['update', version]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,6 @@ async function run() {
 
     if(version) {
       await rustup.install();
-      if (os.platform() !== 'darwin') {
-        // update the GitHub managed VM version of rustup
-        // to leverage newer features like "latest latest compatible nightly"
-        await exec.exec('rustup', ['self', 'update']);
-      }
       await exec.exec('rustup', ['default', version]);
       await exec.exec('rustup', ['update', version]);
 

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -14,6 +14,10 @@ export async function install() {
 
     core.debug('rustup is located under: ' + toolPath);
     core.addPath(path.join(toolPath, 'bin'));
+  } else {
+    // update the GitHub managed VM version of rustup
+    // to leverage newer features like "latest latest compatible nightly"
+    await exec.exec('rustup', ['self', 'update']);
   }
 }
 


### PR DESCRIPTION
fixes: #7

This provides a more reliable CI experience for those using rust nightly. In updating the default GitHub vm version of rustup, we should see the new feature that finds the the most recent version of nightly which has available tools. The output of that looks like the following

```sh
$ rustup update nightly
info: syncing channel updates for 'nightly-x86_64-apple-darwin'
info: latest update on 2019-10-26, rust version 1.40.0-nightly (246be7e1a 2019-10-25)
info: skipping nightly which is missing installed component 'rls-preview'
info: syncing channel updates for 'nightly-2019-10-25-x86_64-apple-darwin'
info: latest update on 2019-10-25, rust version 1.40.0-nightly (10a52c25c 2019-10-24)
info: skipping nightly which is missing installed component 'clippy-preview'
info: syncing channel updates for 'nightly-2019-10-24-x86_64-apple-darwin'
info: latest update on 2019-10-24, rust version 1.40.0-nightly (4a8c5b20c 2019-10-23)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-23-x86_64-apple-darwin'
info: latest update on 2019-10-23, rust version 1.40.0-nightly (d6e4028a0 2019-10-23)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-22-x86_64-apple-darwin'
info: syncing channel updates for 'nightly-2019-10-21-x86_64-apple-darwin'
info: latest update on 2019-10-21, rust version 1.40.0-nightly (7979016af 2019-10-20)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-20-x86_64-apple-darwin'
info: latest update on 2019-10-20, rust version 1.40.0-nightly (c23a7aa77 2019-10-19)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-19-x86_64-apple-darwin'
info: latest update on 2019-10-19, rust version 1.40.0-nightly (518deda77 2019-10-18)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-18-x86_64-apple-darwin'
info: latest update on 2019-10-18, rust version 1.40.0-nightly (fa0f7d008 2019-10-17)
info: skipping nightly which is missing installed component 'clippy-preview'
info: syncing channel updates for 'nightly-2019-10-17-x86_64-apple-darwin'
info: latest update on 2019-10-17, rust version 1.40.0-nightly (0e8a4b441 2019-10-16)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-16-x86_64-apple-darwin'
info: latest update on 2019-10-16, rust version 1.40.0-nightly (237d54ff6 2019-10-15)
info: skipping nightly which is missing installed component 'clippy-preview'
info: syncing channel updates for 'nightly-2019-10-15-x86_64-apple-darwin'
info: latest update on 2019-10-15, rust version 1.40.0-nightly (e413dc36a 2019-10-14)
info: skipping nightly which is missing installed component 'rustc-dev'
info: syncing channel updates for 'nightly-2019-10-14-x86_64-apple-darwin'

  nightly-x86_64-apple-darwin unchanged - rustc 1.40.0-nightly (c27f7568b 2019-10-13)

info: checking for self-updates
```