### PR TITLE
Fix cargo-fmt problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -33,7 +33,7 @@
             "owner": "cargo-fmt",
             "pattern": [
                 {
-                    "regexp": "^(Diff in (\\S+)) at line (\\d):",
+                    "regexp": "^(Diff in (\\S+)) at line (\\d+):",
                     "message": 1,
                     "file": 2,
                     "line": 3


### PR DESCRIPTION
Turns out that it doesn't work because it only accepts single digit lines.